### PR TITLE
[codex] Fix SS6 CMS edit links for nested menu items

### DIFF
--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -279,28 +279,32 @@ class MenuItem extends SuperLink implements PermissionProvider
             ->exclude('ID', $this->ID);
     }
 
-    public function CMSEditLink()
+    public function getCMSEditLink(): ?string
     {
         $link = null;
         if ($this->ParentID) {
-            $link = $this->Parent()->CMSEditLink();
-            $link = preg_replace('/\/item\/([\d]+)\/edit/', '/item/$1', $link);
-            $link = Controller::join_links(
-                $link,
-                'ItemEditForm/field/Children/item',
-                $this->ID,
-                'edit'
-            );
+            $link = $this->Parent()->getCMSEditLink();
+            if ($link) {
+                $link = preg_replace('/\/item\/([\d]+)\/edit/', '/item/$1', $link);
+                $link = Controller::join_links(
+                    $link,
+                    'ItemEditForm/field/Children/item',
+                    $this->ID,
+                    'edit'
+                );
+            }
         }
         else if ($this->MenuSetID) {
-            $link = $this->MenuSet()->CMSEditLink();
-            $link = preg_replace('/\/item\/([\d]+)\/edit/', '/item/$1', $link);
-            $link = Controller::join_links(
-                $link,
-                'ItemEditForm/field/Items/item',
-                $this->ID,
-                'edit'
-            );
+            $link = $this->MenuSet()->getCMSEditLink();
+            if ($link) {
+                $link = preg_replace('/\/item\/([\d]+)\/edit/', '/item/$1', $link);
+                $link = Controller::join_links(
+                    $link,
+                    'ItemEditForm/field/Items/item',
+                    $this->ID,
+                    'edit'
+                );
+            }
         }
         $this->extend('updateCMSEditLink', $link);
         return $link;

--- a/src/Model/MenuSet.php
+++ b/src/Model/MenuSet.php
@@ -433,7 +433,7 @@ class MenuSet extends DataObject implements PermissionProvider
         return $fields;
     }
 
-    public function CMSEditLink()
+    public function getCMSEditLink(): ?string
     {
         $link = null;
         if ($this->ParentID) {


### PR DESCRIPTION
## Summary

- Replace the menu models' custom `CMSEditLink()` overrides with SS6-native `getCMSEditLink()` implementations.
- Update nested menu item link construction to call `getCMSEditLink()` throughout.
- Preserve null handling when a parent edit link cannot be resolved.

## Why

SilverStripe 6 treats `getCMSEditLink()` as the canonical CMS edit-link API, with `CMSEditLink()` deprecated as a framework-level proxy. These menu models were still overriding only `CMSEditLink()`, which could leave SS6 GridField/nested form routing without the package-specific edit-link chain needed for menu sets and menu items.

Fixes #12.

## Validation

- `php -l src/Model/MenuSet.php`
- `php -l src/Model/MenuItem.php`
- `git diff --check`
- confirmed both menu models now declare `getCMSEditLink()` and no package-internal `CMSEditLink()` declarations/calls remain
