### PR TITLE
Remove hidden ID field that breaks menu management POSTs in SS6 settings admin

### DIFF
--- a/src/Model/MenuSet.php
+++ b/src/Model/MenuSet.php
@@ -17,7 +17,6 @@ use SilverStripe\Forms\GridField\GridFieldPageCount;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
 use SilverStripe\Forms\HeaderField;
-use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextField;
@@ -427,7 +426,6 @@ class MenuSet extends DataObject implements PermissionProvider
         }
 
         $menuItemsTab->push($itemsField);
-        $menuItemsTab->push(HiddenField::create('ID', false));
 
         $this->extend('updateCMSFields', $fields);
         return $fields;


### PR DESCRIPTION
## Summary

- Remove the vestigial `HiddenField('ID')` from `MenuSet::getCMSFields()` (and its now-unused import).

Fixes #12.

## Why

The hidden field caused every POST that serializes the MenuSet `ItemEditForm` (drag-reorder of menu items, saving the MenuSet, Items-grid row deletes) to carry the MenuSet's ID as a bare `ID` request var. In SS6, `SiteConfigLeftAndMain` extends `SingleRecordAdmin`, whose record resolution (`LeftAndMain::currentRecordID()`) reads `requestVar('ID')` first — so the settings admin attempted `SiteConfig::get()->byID(<MenuSetID>)`, found nothing, and served `EmptyForm()`, breaking sub-URL routing with:

```
I can't handle sub-URLs on class SilverStripe\Forms\FormRequestHandler.
```

The field has been vestigial since it was introduced in 2019:

- The edited record is bound from the `item/$ID` URL segment during routing; `GridFieldDetailForm_ItemRequest` never reads an `ID` form value.
- `GridFieldOrderableRows::handleReorder` takes its sort data from the grid-namespaced `Items[...]` POST vars.
- No code in this module or its dependencies reads an `ID` request var or form field.
- Core's own GridField item edit forms ship without an `ID` field everywhere.

Other parent contexts are unaffected by the removal: `CMSMain` (SiteTree/multisites parents) sets its record ID from the URL path, which takes precedence, and `ModelAdmin` never consults record IDs for its edit form.

Note: the underlying `SingleRecordAdmin` behaviour is also tracked upstream as silverstripe/silverstripe-framework#11984 (triggered there via `TreeDropdownField`'s `?ID=` lazy-load param), which this module cannot fix from its side.

## Validation

- `php -l src/Model/MenuSet.php`
- Verified no remaining `HiddenField` references in the module
- Root cause traced against silverstripe/framework 6.2.0, silverstripe/admin 3.2.0, silverstripe/siteconfig 6.1.1, symbiote/silverstripe-gridfieldextensions 5.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)